### PR TITLE
Turn Definitions

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,5 +1,5 @@
 class Order < ActiveRecord::Base
-  belongs_to :turn
+  belongs_to :scenario
   belongs_to :asset
   belongs_to :target, class_name: "Asset"
 

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -1,0 +1,3 @@
+class Scenario < ActiveRecord::Base
+	has_many :orders
+end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -4,14 +4,12 @@ class Turn < ActiveRecord::Base
 
   accepts_nested_attributes_for :orders
 
-  scope :in_progress, -> { where(state: "in_progress") }
-
   def self.current
-    in_progress.first
+    self.last
   end
 
   def self.start_next_turn
-    turn = self.create(state: :in_progress, number: self.count + 1)
+    turn = self.create(number: self.count + 1)
     Asset.all.each do |asset|
       turn.orders.create(asset: asset, type: "Attack")
     end

--- a/db/migrate/20130910122058_remove_turn_state.rb
+++ b/db/migrate/20130910122058_remove_turn_state.rb
@@ -1,0 +1,5 @@
+class RemoveTurnState < ActiveRecord::Migration
+  def change
+  	remove_column :turns, :state
+  end
+end

--- a/db/migrate/20130910124508_create_scenarios.rb
+++ b/db/migrate/20130910124508_create_scenarios.rb
@@ -1,0 +1,10 @@
+class CreateScenarios < ActiveRecord::Migration
+  def change
+    create_table :scenarios do |t|
+      t.integer :faction_id
+      t.integer :turn_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130902134728) do
+ActiveRecord::Schema.define(version: 20130910122058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,6 @@ ActiveRecord::Schema.define(version: 20130902134728) do
 
   create_table "turns", force: true do |t|
     t.integer  "number"
-    t.string   "state"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/spec/factories/scenarios.rb
+++ b/spec/factories/scenarios.rb
@@ -1,0 +1,8 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :scenario do
+    faction_id 1
+    turn_id 1
+  end
+end

--- a/spec/factories/turns.rb
+++ b/spec/factories/turns.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :turn do
     number 1
-    state :in_progress
   end
 end

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Scenario do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/turn_spec.rb
+++ b/spec/models/turn_spec.rb
@@ -9,32 +9,23 @@ describe Turn do
       it { should be_nil }
     end
 
-    context "when there is a turn in progress" do
-      before do
-        FactoryGirl.create(:turn, number: 1, state: :in_progress)
-      end
-      it { should be_a Turn }
-    end
-
-    context "when all turns have been processed" do
-      before do
-        FactoryGirl.create(:turn, number: 1, state: :processed)
-      end
-      it { should be_nil }
+    context "when there is at least one turn" do
+      before { FactoryGirl.create(:turn) }
+      it { should_not be_nil }
+      it { should == Turn.last }
     end
   end
 
   describe ".start_next_turn" do
     subject { Turn.start_next_turn }
     it { should be_a Turn }
-    its(:state) { should == :in_progress }
 
     context "when there are no previous Turns" do
       its(:number) { should == 1 }
     end
 
     context "when there is a previous Turn" do
-      before { FactoryGirl.create(:turn, state: :processed, number: 1) }
+      before { FactoryGirl.create(:turn, number: 1) }
       its(:number) { should == 2 }
     end
 


### PR DESCRIPTION
First, removed "state" property from Turn.

And then broke the entire thing because we are in the middle of re-organization the entire database schema.

Notes on a proposal for the new schema to follow.
